### PR TITLE
[Feat]Upgrade OCCI Studio to eclipse 2022-09 version, must be tested …

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,20 @@
 
 OCCI-Studio is a set of Eclipse plugins implementing the [current Open Cloud Computing Interface (OCCI) specification](http://occi-wg.org/about/specification/).
 
+# Building OCCI-Studio with maven
+
+''mvn clean install -Pbuild.products''
+
+The product binaries will be in ''occi-studio/repositories/org.eclipse.cmf.occi.product/target/*.zip''
+
 # Usage
 
 You can refer to the following materials in order to familiarize with OCCI-Studio:
 
 * The OCCI-Studio tutorial is available <a href="https://drive.google.com/open?id=0B7zqdAuZr708VWZCYVZRZzY3YVE">here</a>.
 * The necessary materials to ensure the hands-on experience with OCCI-Studio are available <a href="https://drive.google.com/file/d/1Y6cESS8v9BXJA4H_I6H8RVE1Xzrrx3x_/view?usp=sharing">here</a>.
+
+# Eclipse version 
+
+The current version of the based eclipse platform is : 2022-09
 

--- a/features/org.eclipse.cmf.occi/feature.xml
+++ b/features/org.eclipse.cmf.occi/feature.xml
@@ -226,9 +226,30 @@ litigation.
    </license>
 
    <requires>
-      <import feature="org.eclipse.egit" version="5.0.1.201806211838-r"/>
+   <import feature="org.eclipse.egit" version="6.3.0" match="greaterOrEqual"/>
+   <import feature="org.eclipse.emf" version="2.26.0" match="greaterOrEqual"/>
+   <import feature="org.eclipse.emf.compare.egit" version="1.2.4" match="greaterOrEqual"/>
+   <import feature="org.eclipse.emf.ecoretools.design" version="3.4.0" match="greaterOrEqual"/>
+   <import feature="org.eclipse.epsilon.core.dt.feature" version="1.4.0" match="greaterOrEqual"/>
+   <import feature="org.eclipse.epsilon.core.feature" version="1.4.0" match="greaterOrEqual"/>
+   <import feature="org.eclipse.epsilon.emf.dt.feature" version="1.4.0" match="greaterOrEqual"/>
+   <import feature="org.eclipse.epsilon.emf.feature" version="1.4.0" match="greaterOrEqual"/>
+   <import feature="org.eclipse.mylyn.wikitext_feature" version="3.0.42" match="greaterOrEqual"/>
+   <import feature="org.eclipse.ocl.all.sdk" version="5.4.0" match="greaterOrEqual"/>
+   <import feature="org.eclipse.ocl.examples" version="6.4.0" match="greaterOrEqual"/>
+   <import feature="org.eclipse.pde" version="3.13.100" match="greaterOrEqual"/>
+   <import feature="org.eclipse.sdk" version="4.25.0" match="greaterOrEqual"/>
+   <import feature="org.eclipse.sirius.runtime" version="7.0.4" match="greaterOrEqual"/>
+   <import feature="org.eclipse.sirius.runtime.aql" version="7.0.4" match="greaterOrEqual"/>
+   <import feature="org.eclipse.sirius.runtime.ide.ui" version="7.0.4" match="greaterOrEqual"/>
+   <import feature="org.eclipse.sirius.specifier" version="7.0.4" match="greaterOrEqual"/>
+   <import feature="org.eclipse.xtend.sdk" version="2.28.0" match="greaterOrEqual"/>
+   <import feature="org.eclipse.xtext.sdk" version="2.28.0" match="greaterOrEqual"/>
+   
+      <!-- 
+	  <import feature="org.eclipse.egit" version="5.0.1.201806211838-r"/>
       <import feature="org.eclipse.emf" version="2.14.0.v20180529-1144"/>
-      <import feature="org.eclipse.emf.compare.egit" version="1.2.3.201805161152"/>
+      <import feature="org.eclipse.emf.compare.egit" version="1.2.3.201805161152"/>	
       <import feature="org.eclipse.emf.ecoretools.design" version="3.3.0.201706121316"/>
       <import feature="org.eclipse.epsilon.core.dt.feature" version="1.4.0.201611012202"/>
       <import feature="org.eclipse.epsilon.core.feature" version="1.4.0.201611012202"/>
@@ -245,6 +266,7 @@ litigation.
       <import feature="org.eclipse.sirius.specifier" version="6.0.0.201806111309"/>
       <import feature="org.eclipse.xtend.sdk" version="2.14.0.v20180523-0937"/>
       <import feature="org.eclipse.xtext.sdk" version="2.14.0.v20180523-0937"/>
+	  -->
    </requires>
 
    <plugin

--- a/plugins/org.eclipse.cmf.occi.core.gen.alloy/build.properties
+++ b/plugins/org.eclipse.cmf.occi.core.gen.alloy/build.properties
@@ -14,4 +14,3 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.properties
-jre.compilation.profile = JavaSE-1.8

--- a/plugins/org.eclipse.cmf.occi.core.gen.connector/build.properties
+++ b/plugins/org.eclipse.cmf.occi.core.gen.connector/build.properties
@@ -15,4 +15,3 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.properties
-jre.compilation.profile = JavaSE-1.8

--- a/plugins/org.eclipse.cmf.occi.core.gen.curl/build.properties
+++ b/plugins/org.eclipse.cmf.occi.core.gen.curl/build.properties
@@ -3,4 +3,3 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.properties
-jre.compilation.profile = JavaSE-1.8

--- a/plugins/org.eclipse.cmf.occi.core.gen.design/build.properties
+++ b/plugins/org.eclipse.cmf.occi.core.gen.design/build.properties
@@ -3,4 +3,3 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.properties
-jre.compilation.profile = JavaSE-1.8

--- a/plugins/org.eclipse.cmf.occi.core.gen.latex/build.properties
+++ b/plugins/org.eclipse.cmf.occi.core.gen.latex/build.properties
@@ -3,4 +3,3 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.properties
-jre.compilation.profile = JavaSE-1.8

--- a/plugins/org.eclipse.cmf.occi.core.gen.textile/build.properties
+++ b/plugins/org.eclipse.cmf.occi.core.gen.textile/build.properties
@@ -3,4 +3,3 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.properties
-jre.compilation.profile = JavaSE-1.8

--- a/plugins/org.eclipse.cmf.occi.core.gen.uris/build.properties
+++ b/plugins/org.eclipse.cmf.occi.core.gen.uris/build.properties
@@ -3,4 +3,3 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.properties
-jre.compilation.profile = JavaSE-1.8

--- a/plugins/org.eclipse.cmf.occi.core.gen.xml/build.properties
+++ b/plugins/org.eclipse.cmf.occi.core.gen.xml/build.properties
@@ -3,4 +3,3 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.properties
-jre.compilation.profile = JavaSE-1.8

--- a/pom.xml
+++ b/pom.xml
@@ -146,17 +146,23 @@
   </profiles>
 
   <properties>
-    <tycho-version>1.0.0</tycho-version>
+    <!-- <tycho-version>1.4.0</tycho-version> -->
+	<tycho-version>2.3.0</tycho-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <repositories>
     <!-- configure p2 repository to resolve against -->
 	<repository>
-      <id>photon</id>
+      <id>2022-09</id>
       <layout>p2</layout>
-      <url>http://download.eclipse.org/releases/photon</url>
+      <url>https://download.eclipse.org/releases/2022-09/</url>
     </repository>
+	<repository>
+		<id>orbit</id>
+		<layout>p2</layout>
+		<url>https://download.eclipse.org/tools/orbit/downloads/drops/R20220830213456/repository</url>
+	</repository>
     <repository>
       <id>mvnrepository</id>
       <url>http://repo1.maven.org/maven2</url>
@@ -167,11 +173,16 @@
         <enabled>true</enabled>
       </releases>
     </repository>
-    <repository>
+    <!-- <repository>
     <id>epsilonrepository</id>
      <url>http://download.eclipse.org/epsilon/updates/1.4</url>
      <layout>p2</layout>
-    </repository>
+    </repository> -->
+	<repository>
+            <id>epsilonrepository</id>
+            <url>http://download.eclipse.org/epsilon/updates/2.4/</url>
+            <layout>p2</layout>
+   </repository>
   </repositories>
   <distributionManagement>
     <snapshotRepository>
@@ -194,6 +205,22 @@
         <artifactId>target-platform-configuration</artifactId>
         <version>${tycho-version}</version>
         <configuration>
+		  <executionEnvironment>JavaSE-11</executionEnvironment>
+		  <!-- <resolveWithExecutionEnvironmentConstraints>false</resolveWithExecutionEnvironmentConstraints> -->
+		  <dependency-resolution>
+                    <extraRequirements>
+                        <requirement>
+                            <type>eclipse-plugin</type>
+                            <id>org.eclipse.equinox.event</id>
+                            <versionRange>0.0.0</versionRange>
+                        </requirement>
+						<requirement>
+                            <type>eclipse-plugin</type>
+                            <id>org.eclipse.equinox.ds</id>
+                            <versionRange>0.0.0</versionRange>
+                        </requirement>
+                    </extraRequirements> 
+                </dependency-resolution>
           <environments>
             <environment>
               <os>win32</os>

--- a/repositories/org.eclipse.cmf.occi.product/OCCI-Studio.product
+++ b/repositories/org.eclipse.cmf.occi.product/OCCI-Studio.product
@@ -14,7 +14,7 @@
    </configIni>
 
    <launcherArgs>
-      <vmArgs>-Dosgi.requiredJavaVersion=1.8 -Xms256m -Xmx1024m
+      <vmArgs>-Dosgi.requiredJavaVersion=11 -Xms256m -Xmx1024m
       </vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
@@ -33,7 +33,7 @@
    </launcher>
 
    <vm>
-      <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8</windows>
+      <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</windows>
    </vm>
 
 
@@ -45,6 +45,7 @@
    </features>
 
    <configurations>
+	  <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.ds" autoStart="true" startLevel="2" />
@@ -58,8 +59,8 @@
    </configurations>
 
    <repositories>
-      <repository location="https://dl.bintray.com/occiware/OCCI-Studio/update-site/current-release" enabled="true" />
-      <repository location="http://download.eclipse.org/releases/photon" enabled="true" />
+      <!-- <repository location="https://dl.bintray.com/occiware/OCCI-Studio/update-site/current-release" enabled="true" /> -->
+      <repository location="https://download.eclipse.org/releases/2022-09" enabled="true" />
    </repositories>
 
    <preferencesInfo>


### PR DESCRIPTION
…with models and generators before going to master branch
Also updated Tycho to 2.3.0 version.